### PR TITLE
fix a BUG that the arrow changed after the content padding doesn't change

### DIFF
--- a/happy-bubble/src/main/java/com/xujiaji/happybubble/BubbleLayout.java
+++ b/happy-bubble/src/main/java/com/xujiaji/happybubble/BubbleLayout.java
@@ -314,6 +314,7 @@ public class BubbleLayout extends FrameLayout
     public void setLook(Look mLook)
     {
         this.mLook = mLook;
+        initPadding();
     }
 
     public void setLookPosition(int mLookPosition)
@@ -329,6 +330,7 @@ public class BubbleLayout extends FrameLayout
     public void setLookLength(int mLookLength)
     {
         this.mLookLength = mLookLength;
+        initPadding();
     }
 
     public void setShadowColor(int mShadowColor)


### PR DESCRIPTION
If you change the arrow attribute such as `lookLenght`, `look` during app running, it's will cause a display error.

![screenshot](https://user-images.githubusercontent.com/14055589/40575710-9b57887c-611c-11e8-8985-12017f60e06f.png)