### PR TITLE
fix: mPaint NPE when test with robolectric

### DIFF
--- a/happy-bubble/src/main/java/com/xujiaji/happybubble/BubbleLayout.java
+++ b/happy-bubble/src/main/java/com/xujiaji/happybubble/BubbleLayout.java
@@ -109,7 +109,6 @@ public class BubbleLayout extends FrameLayout {
 
     public BubbleLayout(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
-        setLayerType(LAYER_TYPE_SOFTWARE, null);
         setWillNotDraw(false);
         initAttr(context.obtainStyledAttributes(attrs, R.styleable.BubbleLayout, defStyleAttr, 0));
         mPaint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.DITHER_FLAG);
@@ -117,6 +116,7 @@ public class BubbleLayout extends FrameLayout {
         mPath = new Path();
         mBubbleImageBgPaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_IN));
         initPadding();
+        setLayerType(LAYER_TYPE_SOFTWARE, null);
     }
 
     public void initPadding() {


### PR DESCRIPTION
当用robolectric做单元测试时，BubbleLayout.<init> 会调setLayerType，而setLayerType会触发invalidate，这个时间mPaint还没有初始化，报空指针。

Caused by: java.lang.NullPointerException
	at com.xujiaji.happybubble.BubbleLayout.initData(BubbleLayout.java:203)
	at com.xujiaji.happybubble.BubbleLayout.invalidate(BubbleLayout.java:188)
	at android.view.View.setLayerPaint(View.java:20945)
	at android.view.View.setLayerType(View.java:20890)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at org.robolectric.shadows.ShadowView$_View_$$Reflector21.setLayerType(Unknown Source)
	at org.robolectric.shadows.ShadowView.setLayerType(ShadowView.java:177)
	at android.view.View.setLayerType(View.java)
	at com.xujiaji.happybubble.BubbleLayout.<init>(BubbleLayout.java:112)
	at com.xujiaji.happybubble.BubbleLayout.<init>(BubbleLayout.java:107)

所以把setLayerType写到mPaint初始化之后